### PR TITLE
Switch from console.log to `debug` module logging.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@mawhea/mongopubsub": "1.0.0"
+        "@mawhea/mongopubsub": "1.0.0",
+        "debug": "^4.3.4"
       },
       "devDependencies": {
         "@types/graphql": "^14.5.0",
@@ -2269,7 +2270,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4392,8 +4392,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -7427,7 +7426,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -9069,8 +9067,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "prepublishOnly": "npm run test"
   },
   "dependencies": {
-    "@mawhea/mongopubsub": "1.0.0"
+    "@mawhea/mongopubsub": "1.0.0",
+    "debug": "^4.3.4"
   },
   "peerDependencies": {
     "graphql-subscriptions": "^1.0.0 || ^2.0.0",


### PR DESCRIPTION
I was not a fan of the `console.log` calls in the main class, so I wanted to allow users of this library to toggle the logging when needed. This PR replaces the `console.log` calls with the `debug` module which is used by a large number of libraries to facilitate just that.

I saw on your other repo that you just commented out the log calls, but this gives end users another tool for debugging their apps.